### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "proxyquire": "^1.7.2"
   },
   "dependencies": {
+    "file-type": "2.6.0",
     "fs-extra": "^0.30.0",
     "js2xmlparser": "^0.1.9",
     "lodash": "^3.7.0",
-    "node-uuid": "^1.4.3",
-    "file-type": "2.6.0",
-    "mime": "1.3.4"
+    "mime": "1.3.4",
+    "uuid": "^3.0.0"
   }
 }

--- a/writer.js
+++ b/writer.js
@@ -1,7 +1,7 @@
 'use strict';
 var fs = require('fs-extra'),
     path = require('path'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     xml = require('js2xmlparser');
 
 module.exports = {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.