### PR TITLE
Added extra validation to undefined type

### DIFF
--- a/beans/step.js
+++ b/beans/step.js
@@ -20,7 +20,6 @@ Step.prototype.end = function (status, timestamp) {
 };
 
 Step.prototype.toXML = function () {
-	console.log('Step.prototype.toXML', this.start, this.stop);
     var start = (this.start == "" || typeof this.start === "undefined") ? Date.now() : this.start;
     var stop = (this.stop == "" || typeof this.stop === "undefined") ? Date.now() : this.stop;
     var status = (this.status == "" || typeof this.status === "undefined") ? "failed" : this.status;

--- a/beans/step.js
+++ b/beans/step.js
@@ -20,9 +20,9 @@ Step.prototype.end = function (status, timestamp) {
 };
 
 Step.prototype.toXML = function () {
-    var start = (this.start == "" || typeof this.start === "undefined") ? Date.now() : this.start;
-    var stop = (this.stop == "" || typeof this.stop === "undefined") ? Date.now() : this.stop;
-    var status = (this.status == "" || typeof this.status === "undefined") ? "failed" : this.status;
+    var start = (this.start == '' || typeof this.start === 'undefined') ? Date.now() : this.start;
+    var stop = (this.stop == '' || typeof this.stop === 'undefined') ? Date.now() : this.stop;
+    var status = (this.status == '' || typeof this.status === 'undefined') ? "failed" : this.status;
 
     return {
         '@': {

--- a/beans/step.js
+++ b/beans/step.js
@@ -22,7 +22,7 @@ Step.prototype.end = function (status, timestamp) {
 Step.prototype.toXML = function () {
     var start = (this.start == '' || typeof this.start === 'undefined') ? Date.now() : this.start;
     var stop = (this.stop == '' || typeof this.stop === 'undefined') ? Date.now() : this.stop;
-    var status = (this.status == '' || typeof this.status === 'undefined') ? "failed" : this.status;
+    var status = (this.status == '' || typeof this.status === 'undefined') ? 'failed' : this.status;
 
     return {
         '@': {

--- a/beans/step.js
+++ b/beans/step.js
@@ -20,11 +20,16 @@ Step.prototype.end = function (status, timestamp) {
 };
 
 Step.prototype.toXML = function () {
+	console.log('Step.prototype.toXML', this.start, this.stop);
+    var start = (this.start == "" || typeof this.start === "undefined") ? Date.now() : this.start;
+    var stop = (this.stop == "" || typeof this.stop === "undefined") ? Date.now() : this.stop;
+    var status = (this.status == "" || typeof this.status === "undefined") ? "failed" : this.status;
+
     return {
         '@': {
-            start: this.start,
-            stop: this.stop,
-            status: this.status
+            start: start,
+            stop: stop,
+            status: status
         },
         name: this.name,
         title: this.name,

--- a/beans/suite.js
+++ b/beans/suite.js
@@ -16,13 +16,13 @@ Suite.prototype.addTest = function(test) {
 };
 
 Suite.prototype.toXML = function() {
-	var start = (this.start == "" || typeof this.start === "undefined") ? Date.now() : this.start;
-    var stop = (this.stop == "" || typeof this.stop === "undefined") ? Date.now() : this.stop;
+	var start = (this.start == '' || typeof this.start === 'undefined') ? Date.now() : this.start;
+    var stop = (this.stop == '' || typeof this.stop === 'undefined') ? Date.now() : this.stop;
     return {
         '@': {
             'xmlns:ns2' : 'urn:model.allure.qatools.yandex.ru',
             start: start,
-            stop: stop,
+            stop: stop
         },
         name: this.name,
         title: this.name,

--- a/beans/suite.js
+++ b/beans/suite.js
@@ -16,7 +16,7 @@ Suite.prototype.addTest = function(test) {
 };
 
 Suite.prototype.toXML = function() {
-	var start = (this.start == '' || typeof this.start === 'undefined') ? Date.now() : this.start;
+    var start = (this.start == '' || typeof this.start === 'undefined') ? Date.now() : this.start;
     var stop = (this.stop == '' || typeof this.stop === 'undefined') ? Date.now() : this.stop;
     return {
         '@': {

--- a/beans/suite.js
+++ b/beans/suite.js
@@ -16,7 +16,6 @@ Suite.prototype.addTest = function(test) {
 };
 
 Suite.prototype.toXML = function() {
-	console.log('Suite.prototype.toXML', this.start, this.stop);
 	var start = (this.start == "" || typeof this.start === "undefined") ? Date.now() : this.start;
     var stop = (this.stop == "" || typeof this.stop === "undefined") ? Date.now() : this.stop;
     return {

--- a/beans/suite.js
+++ b/beans/suite.js
@@ -16,11 +16,14 @@ Suite.prototype.addTest = function(test) {
 };
 
 Suite.prototype.toXML = function() {
+	console.log('Suite.prototype.toXML', this.start, this.stop);
+	var start = (this.start == "" || typeof this.start === "undefined") ? Date.now() : this.start;
+    var stop = (this.stop == "" || typeof this.stop === "undefined") ? Date.now() : this.stop;
     return {
         '@': {
             'xmlns:ns2' : 'urn:model.allure.qatools.yandex.ru',
-            start: this.start,
-            stop: this.stop
+            start: start,
+            stop: stop,
         },
         name: this.name,
         title: this.name,

--- a/beans/test.js
+++ b/beans/test.js
@@ -46,7 +46,6 @@ Test.prototype.end = function (status, error, timestamp) {
 };
 
 Test.prototype.toXML = function () {
-	console.log('Test.prototype.toXML', this.start, this.stop);
     var start = (this.start == "" || typeof this.start === "undefined") ? Date.now() : this.start;
     var stop = (this.stop == "" || typeof this.stop === "undefined") ? Date.now() : this.stop;
     var status = (this.status == "" || typeof this.status === "undefined") ? "failed" : this.status;

--- a/beans/test.js
+++ b/beans/test.js
@@ -48,7 +48,7 @@ Test.prototype.end = function (status, error, timestamp) {
 Test.prototype.toXML = function () {
     var start = (this.start == '' || typeof this.start === 'undefined') ? Date.now() : this.start;
     var stop = (this.stop == '' || typeof this.stop === 'undefined') ? Date.now() : this.stop;
-    var status = (this.status == '' || typeof this.status === 'undefined') ? "failed" : this.status;
+    var status = (this.status == '' || typeof this.status === 'undefined') ? 'failed' : this.status;
     var result = {
         '@': {
             start: start,

--- a/beans/test.js
+++ b/beans/test.js
@@ -46,11 +46,15 @@ Test.prototype.end = function (status, error, timestamp) {
 };
 
 Test.prototype.toXML = function () {
+	console.log('Test.prototype.toXML', this.start, this.stop);
+    var start = (this.start == "" || typeof this.start === "undefined") ? Date.now() : this.start;
+    var stop = (this.stop == "" || typeof this.stop === "undefined") ? Date.now() : this.stop;
+    var status = (this.status == "" || typeof this.status === "undefined") ? "failed" : this.status;
     var result = {
         '@': {
-            start: this.start,
-            stop: this.stop,
-            status: this.status
+            start: start,
+            stop: stop,
+            status: status
         },
         name: this.name,
         title: this.name,

--- a/beans/test.js
+++ b/beans/test.js
@@ -46,9 +46,9 @@ Test.prototype.end = function (status, error, timestamp) {
 };
 
 Test.prototype.toXML = function () {
-    var start = (this.start == "" || typeof this.start === "undefined") ? Date.now() : this.start;
-    var stop = (this.stop == "" || typeof this.stop === "undefined") ? Date.now() : this.stop;
-    var status = (this.status == "" || typeof this.status === "undefined") ? "failed" : this.status;
+    var start = (this.start == '' || typeof this.start === 'undefined') ? Date.now() : this.start;
+    var stop = (this.stop == '' || typeof this.stop === 'undefined') ? Date.now() : this.stop;
+    var status = (this.status == '' || typeof this.status === 'undefined') ? "failed" : this.status;
     var result = {
         '@': {
             start: start,


### PR DESCRIPTION
At some cases, while generating xml reports the allure common can't get correctly the value from start and stop. In that cases they pass values as empty string making allure report generation to fail causing errors like:

```javascript
Exception in thread "main" java.lang.NumberFormatException: For input string: ""
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
    at java.lang.Long.parseLong(Long.java:601)
    at java.lang.Long.valueOf(Long.java:803)
    at com.sun.xml.internal.bind.DatatypeConverterImpl._parseLong(DatatypeConverterImpl.java:118)
    at ru.yandex.qatools.allure.model.TestCaseResult_JaxbXducedAccessor_stop.parse(TransducedAccessor_field_Long.java:50)
    at com.sun.xml.internal.bind.v2.runtime.unmarshaller.StructureLoader.startElement(StructureLoader.java:195)
    at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallingContext._startElement(UnmarshallingContext.java:559)
    at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallingContext.startElement(UnmarshallingContext.java:538)
    at com.sun.xml.internal.bind.v2.runtime.unmarshaller.SAXConnector.startElement(SAXConnector.java:153)
    at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.startElement(AbstractSAXParser.java:509)
    at com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.scanStartElement(XMLNSDocumentScannerImpl.java:380)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2787)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:606)
    at com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.next(XMLNSDocumentScannerImpl.java:118)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:510)
    at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:848)
    at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:777)
    at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
    at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1213)
    at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:643)
    at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal0(UnmarshallerImpl.java:243)
    at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal(UnmarshallerImpl.java:221)
    at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal(UnmarshallerImpl.java:276)
    at javax.xml.bind.JAXB.unmarshal(JAXB.java:242)
    at ru.yandex.qatools.allure.commons.AllureFileUtils.unmarshal(AllureFileUtils.java:59)
    at ru.yandex.qatools.allure.commons.AllureFileUtils.unmarshal(AllureFileUtils.java:50)
    at ru.yandex.qatools.allure.commons.AllureFileUtils.unmarshal(AllureFileUtils.java:40)
    at ru.yandex.qatools.allure.data.io.TestSuiteReader$TestSuiteResultIterator.next(TestSuiteReader.java:48)
    at ru.yandex.qatools.allure.data.io.TestSuiteReader$TestSuiteResultIterator.next(TestSuiteReader.java:1)
    at ru.yandex.qatools.allure.data.io.TestCaseReader$TestCaseResultIterator.nextSuite(TestCaseReader.java:46)
    at ru.yandex.qatools.allure.data.io.TestCaseReader$TestCaseResultIterator.hasNext(TestCaseReader.java:56)
    at ru.yandex.qatools.allure.data.AllureReportGenerator.generate(AllureReportGenerator.java:61)
    at ru.yandex.qatools.allure.data.AllureReportGenerator.generate(AllureReportGenerator.java:53)
    at ru.yandex.qatools.allure.AllureMain.main(AllureMain.java:48)
Command aborted due to exception {}.
org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
    at org.apache.commons.exec.DefaultExecutor.executeInternal(DefaultExecutor.java:404)
    at org.apache.commons.exec.DefaultExecutor.execute(DefaultExecutor.java:166)
    at org.apache.commons.exec.DefaultExecutor.execute(DefaultExecutor.java:153)
    at ru.yandex.qatools.allure.command.ReportGenerate.runUnsafe(ReportGenerate.java:48)
    at ru.yandex.qatools.allure.command.AbstractCommand.run(AbstractCommand.java:52)
    at ru.yandex.qatools.allure.CommandLine.main(CommandLine.java:46)
```

To fix that, i've created some variables to handle data before it generates the actual XML data.
Some issues already related to this at other projects:

https://github.com/webdriverio/webdriverio/issues/1432
https://github.com/webdriverio/wdio-allure-reporter/issues/26

I'm not shure if the beans folder it's the best place to fix the actual problem, but at some cases where the event it's waiting for an execution to be finishe like "waitForExist" from webdriver causes to pass undefined data while generating de XML.