### PR TITLE
Fix for grammatical mistake - **There are no any steps running**

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ Allure.prototype.startStep = function(stepName, timestamp) {
 Allure.prototype.endStep = function(status, timestamp) {
     var suite = this.getCurrentSuite();
     if (!suite || !(suite.currentStep instanceof Step)) {
-        console.warn('allure-js-commons: Unexpected endStep(). There are no any steps running');
+        console.warn('allure-js-commons: Unexpected endStep(). There is not running step');
         return;
     }
 

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ Allure.prototype.startStep = function(stepName, timestamp) {
 Allure.prototype.endStep = function(status, timestamp) {
     var suite = this.getCurrentSuite();
     if (!suite || !(suite.currentStep instanceof Step)) {
-        console.warn('allure-js-commons: Unexpected endStep(). There is not running step');
+        console.warn('allure-js-commons: Unexpected endStep(). There is no running step');
         return;
     }
 


### PR DESCRIPTION
Grammatical mistake, Following are the alternatives
There is no step in running state
No Running Step
None of the step is in running state