### PR TITLE
Fix typo in 'use strict'

### DIFF
--- a/beans/description.js
+++ b/beans/description.js
@@ -1,4 +1,4 @@
-'use srtict';
+'use strict';
 
 var TYPES = {
     TEXT: 'text',


### PR DESCRIPTION
Fixes a typo in `beans/description.js` where it should say `'use strict'` but instead said `'use srtict'`